### PR TITLE
Fixed mismatch in setting name for the termination prompt

### DIFF
--- a/src/Workshop.SemanticKernel.MultiAgent/Scenarios.cs
+++ b/src/Workshop.SemanticKernel.MultiAgent/Scenarios.cs
@@ -17,7 +17,7 @@ namespace Workshop.SemanticKernel.MultiAgent
             public void Initialize(Settings.ScenarioSettings scenarioSettings, Kernel scenarioKernel, List<ChatCompletionAgent> agents)
             {
                 
-                var terminateFunction = AgentGroupChat.CreatePromptFunctionForStrategy(scenarioSettings.TerminatePrompt);
+                var terminateFunction = AgentGroupChat.CreatePromptFunctionForStrategy(scenarioSettings.TerminationPrompt);
                 var selectionFunction = AgentGroupChat.CreatePromptFunctionForStrategy(scenarioSettings.SelectionPrompt);
             
                 chat.ExecutionSettings = new AgentGroupChatSettings 
@@ -47,7 +47,7 @@ namespace Workshop.SemanticKernel.MultiAgent
                 chat.AddChatMessage(new ChatMessageContent(AuthorRole.User, prompt));
                 await foreach (var content in chat.InvokeAsync())
                 {
-                    Console.WriteLine();
+                   Console.WriteLine();
                     Console.WriteLine($"# {content.Role} - {content.AuthorName ?? "*"}: '{content.Content}'");
                     Console.WriteLine();
                 }

--- a/src/Workshop.SemanticKernel.MultiAgent/Settings.cs
+++ b/src/Workshop.SemanticKernel.MultiAgent/Settings.cs
@@ -40,7 +40,7 @@ namespace Workshop.SemanticKernel.MultiAgent
             public string Description { get; set; } = string.Empty;
             public List<string> Agents { get; set; } = new ();
             public string SelectionPrompt { get; set; } = string.Empty;
-            public string TerminatePrompt { get; set; } = string.Empty;
+            public string TerminationPrompt { get; set; } = string.Empty;
             public List<string> TerminationAgents { get; set; } = new ();
             public string TerminationSuccess { get; set; } = string.Empty;
             public bool Enabled { get; set; } = true;


### PR DESCRIPTION
Fixed mismatch in setting name for the termination prompt which was causing an error in the agents workflow